### PR TITLE
Disallow gzip Content-Encoding

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,9 @@ for(var path in config.map) {
       if (conf.capture || program.capture) {
         console.log('Capture Mode enabled for mocks!');
 
+        conf.proxy.onProxyReq = function(proxyReq, req, res) {
+          proxyReq.removeHeader('Accept-Encoding');
+        }
         conf.proxy.onProxyRes = function(proxyRes, req, res) {
           var body = "";
           if (proxyRes.statusCode < 404) {


### PR DESCRIPTION
When cloning files from the proxy, the default is to allow gzip and deflate, but the main script does not handle that at all...